### PR TITLE
ZEN-3062 Fix QRC links

### DIFF
--- a/_data/content_tree.yml
+++ b/_data/content_tree.yml
@@ -17,7 +17,7 @@ areas:
     type: internal
     new_window: true
   - title: RepreZen API Studio Reference Card
-    url: https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/RepreZen%20RAPID-ML%20QRC.pdf
+    url: https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/current/RepreZen%20API%20Studio%20QRC.pdf
     type: external
 - name: Code Gen
   articles:

--- a/_site/404.html
+++ b/_site/404.html
@@ -81,7 +81,7 @@
       
       
       
-      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/RepreZen%20RAPID-ML%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
+      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/current/RepreZen%20API%20Studio%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
       
       
     </ul>

--- a/_site/codegen_custom_swagger_gentemplate/index.html
+++ b/_site/codegen_custom_swagger_gentemplate/index.html
@@ -81,7 +81,7 @@
       
       
       
-      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/RepreZen%20RAPID-ML%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
+      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/current/RepreZen%20API%20Studio%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
       
       
     </ul>

--- a/_site/codegen_intro/index.html
+++ b/_site/codegen_intro/index.html
@@ -81,7 +81,7 @@
       
       
       
-      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/RepreZen%20RAPID-ML%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
+      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/current/RepreZen%20API%20Studio%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
       
       
     </ul>

--- a/_site/codegen_sharing/index.html
+++ b/_site/codegen_sharing/index.html
@@ -81,7 +81,7 @@
       
       
       
-      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/RepreZen%20RAPID-ML%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
+      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/current/RepreZen%20API%20Studio%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
       
       
     </ul>

--- a/_site/codegen_swagger_codegen/index.html
+++ b/_site/codegen_swagger_codegen/index.html
@@ -81,7 +81,7 @@
       
       
       
-      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/RepreZen%20RAPID-ML%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
+      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/current/RepreZen%20API%20Studio%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
       
       
     </ul>

--- a/_site/index.html
+++ b/_site/index.html
@@ -81,7 +81,7 @@
       
       
       
-      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/RepreZen%20RAPID-ML%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
+      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/current/RepreZen%20API%20Studio%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
       
       
     </ul>
@@ -290,7 +290,7 @@
 <p><a href="/learning_rapid_ml/" target="_blank">Learning RAPID-ML</a></p>
 </li>
 <li>
-<p><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/RepreZen%20RAPID-ML%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></p>
+<p><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/current/RepreZen%20API%20Studio%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></p>
 </li>
 </ul>
 </div>

--- a/_site/swagger_normalizer/index.html
+++ b/_site/swagger_normalizer/index.html
@@ -81,7 +81,7 @@
       
       
       
-      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/RepreZen%20RAPID-ML%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
+      <li class=""><a href="https://19dd14f1bca25029f68d-656faf528029c44dd1ad9f4b523fa82b.ssl.cf5.rackcdn.com/current/RepreZen%20API%20Studio%20QRC.pdf" target="_blank">RepreZen API Studio Reference Card</a></li>
       
       
     </ul>


### PR DESCRIPTION
@daffinm Updated site ready for QA at http://reprezen.github.io/docs-qa/.

Affected URLs are in top page under Core Docs and in drop-down menu at top of all pages.