### PR TITLE
ZEN-4479 - Correct case in top-level menu

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -139,7 +139,7 @@
 
   
   <li class="dropdown">
-    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">openapi <span class="caret"></span></a>
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">OpenAPI<span class="caret"></span></a>
     <ul class="dropdown-menu">
       
       


### PR DESCRIPTION
Correct case in top-level "openapi" menu to "OpenAPI".

@andylowry , please review. If it's OK, please merge & deploy changes, or point me to docs so I can do it. 